### PR TITLE
Expand functionality

### DIFF
--- a/Core/NetArgumentParser/src/Attributes/Extensions/PropertyInfoEnumerableExtensions.cs
+++ b/Core/NetArgumentParser/src/Attributes/Extensions/PropertyInfoEnumerableExtensions.cs
@@ -11,7 +11,37 @@ internal static class PropertyInfoEnumerableExtensions
     internal static IEnumerable<IGrouping<OptionGroupAttribute?, PropertyInfo>> GroupOptionAttributes(
         this IEnumerable<PropertyInfo> properties)
     {
+        ExtendedArgumentNullException.ThrowIfNull(properties, nameof(properties));
         return properties.GroupBy(t => t.GetCustomAttribute<OptionGroupAttribute>());
+    }
+
+    internal static T? FindOptionGroupAttributeWithBestParameters<T>(
+        this IEnumerable<PropertyInfo> properties,
+        string groupId)
+        where T : OptionGroupBaseAttribute
+    {
+        ExtendedArgumentNullException.ThrowIfNull(properties, nameof(properties));
+        ExtendedArgumentNullException.ThrowIfNull(groupId, nameof(groupId));
+
+        List<T> candidates = properties
+            .Select(t => t.GetCustomAttribute<T>())
+            .Where(t => t is not null && t.Id == groupId)
+            .ToList()!;
+
+        bool isGroupWithInfoExists = candidates.Any(t =>
+        {
+            return !string.IsNullOrEmpty(t.Header)
+                || !string.IsNullOrEmpty(t.Description);
+        });
+
+        if (!isGroupWithInfoExists)
+            return candidates.FirstOrDefault();
+
+        T? bestGroupByHeader = candidates
+            .FirstOrDefault(t => !string.IsNullOrEmpty(t.Header));
+
+        return bestGroupByHeader ?? candidates
+            .FirstOrDefault(t => !string.IsNullOrEmpty(t.Description));
     }
 
     internal static Dictionary<PropertyInfo, ICommonOption> CreateOptions(

--- a/Core/NetArgumentParser/src/Attributes/Extensions/PropertyInfoExtensions.cs
+++ b/Core/NetArgumentParser/src/Attributes/Extensions/PropertyInfoExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Reflection;
 using NetArgumentParser.Options;
@@ -6,22 +7,29 @@ namespace NetArgumentParser.Attributes.Extensions;
 
 internal static class PropertyInfoExtensions
 {
+    internal static bool HasAttribute<T>(this PropertyInfo propertyInfo)
+        where T : Attribute
+    {
+        ExtendedArgumentNullException.ThrowIfNull(propertyInfo, nameof(propertyInfo));
+        return propertyInfo.GetCustomAttribute<T>() is not null;
+    }
+
     internal static bool HasOptionAttribute(this PropertyInfo propertyInfo)
     {
         ExtendedArgumentNullException.ThrowIfNull(propertyInfo, nameof(propertyInfo));
-        return propertyInfo.GetCustomAttribute<CommonOptionAttribute>() is not null;
+        return propertyInfo.HasAttribute<CommonOptionAttribute>();
     }
 
     internal static bool HasOptionGroupAttribute(this PropertyInfo propertyInfo)
     {
         ExtendedArgumentNullException.ThrowIfNull(propertyInfo, nameof(propertyInfo));
-        return propertyInfo.GetCustomAttribute<OptionGroupAttribute>() is not null;
+        return propertyInfo.HasAttribute<OptionGroupAttribute>();
     }
 
     internal static bool HasMutuallyExclusiveOptionGroupAttribute(this PropertyInfo propertyInfo)
     {
         ExtendedArgumentNullException.ThrowIfNull(propertyInfo, nameof(propertyInfo));
-        return propertyInfo.GetCustomAttribute<MutuallyExclusiveOptionGroupAttribute>() is not null;
+        return propertyInfo.HasAttribute<MutuallyExclusiveOptionGroupAttribute>();
     }
 
     internal static bool HasSubcommandAttribute(this PropertyInfo propertyInfo)

--- a/Core/NetArgumentParser/src/Attributes/Extensions/TypeExtensions.cs
+++ b/Core/NetArgumentParser/src/Attributes/Extensions/TypeExtensions.cs
@@ -6,11 +6,14 @@ internal static class TypeExtensions
 {
     internal static Type RemoveNullable(this Type type)
     {
+        ExtendedArgumentNullException.ThrowIfNull(type, nameof(type));
         return Nullable.GetUnderlyingType(type) ?? type;
     }
 
     internal static object? GetDefaultValue(this Type type)
     {
+        ExtendedArgumentNullException.ThrowIfNull(type, nameof(type));
+
         return type.IsValueType
             ? Activator.CreateInstance(type)
             : null;
@@ -18,6 +21,8 @@ internal static class TypeExtensions
 
     internal static object GetValueTypeDefaultValue(this Type type)
     {
+        ExtendedArgumentNullException.ThrowIfNull(type, nameof(type));
+
         if (!type.IsValueType)
             throw new ArgumentException($"{type.FullName} is not value type.", nameof(type));
 

--- a/Core/NetArgumentParser/src/Generators/ArgumentParserGenerator.cs
+++ b/Core/NetArgumentParser/src/Generators/ArgumentParserGenerator.cs
@@ -66,6 +66,12 @@ public class ArgumentParserGenerator
         {
             OptionGroupAttribute? attribute = attributeGroup.Key;
 
+            if (attribute is not null)
+            {
+                attribute = optionMap.Keys
+                    .FindOptionGroupAttributeWithBestParameters<OptionGroupAttribute>(attribute.Id);
+            }
+
             OptionGroup<ICommonOption>? optionGroup = attribute is not null
                 ? parserQuantum.AddOptionGroup(attribute.Header, attribute.Description)
                 : null;
@@ -103,6 +109,14 @@ public class ArgumentParserGenerator
 
             if (attribute is null)
                 continue;
+
+            MutuallyExclusiveOptionGroupAttribute? attributeWithBestParameters = rootQuantum.Options
+                .Select(t => t.Key)
+                .FindOptionGroupAttributeWithBestParameters<MutuallyExclusiveOptionGroupAttribute>(
+                    attribute.Id);
+
+            if (attributeWithBestParameters is not null)
+                attribute = attributeWithBestParameters;
 
             IEnumerable<ICommonOption> groupOptions = group.Select(t => t.Value);
 

--- a/Core/NetArgumentParser/src/Options/ValueOption.cs
+++ b/Core/NetArgumentParser/src/Options/ValueOption.cs
@@ -10,7 +10,7 @@ namespace NetArgumentParser.Options;
 
 public class ValueOption<T> : CommonOption, IValueOption<T>
 {
-    private readonly List<T> _choices;
+    private List<T> _choices;
 
     public ValueOption(
         string longName,
@@ -106,13 +106,18 @@ public class ValueOption<T> : CommonOption, IValueOption<T>
 
     public string MetaVariable { get; }
 
-    public DefaultOptionValue<T>? DefaultValue { get; }
-    public OptionValueRestriction<T>? ValueRestriction { get; }
+    public DefaultOptionValue<T>? DefaultValue { get; set; }
+    public OptionValueRestriction<T>? ValueRestriction { get; set; }
     public IValueConverter<T>? Converter { get; set; }
 
     public IReadOnlyCollection<T> Choices => _choices;
     public bool HasDefaultValue => DefaultValue is not null;
     public bool HasConverter => Converter is not null;
+
+    public void ChangeChoices(IEnumerable<T>? choices)
+    {
+        _choices = new List<T>(choices ?? []);
+    }
 
     public bool TrySetConverter(IValueConverter converter)
     {
@@ -241,7 +246,7 @@ public class ValueOption<T> : CommonOption, IValueOption<T>
 
     protected string GetExtendedMetavariable()
     {
-        return Choices.Count > 0
+        return _choices.Count > 0
             ? "{" + string.Join(",", GetAllowedValues()) + "}"
             : MetaVariable;
     }

--- a/Core/NetArgumentParser/src/Subcommands/ParserQuantum.cs
+++ b/Core/NetArgumentParser/src/Subcommands/ParserQuantum.cs
@@ -179,6 +179,21 @@ public class ParserQuantum : IOptionSetOrganizer, ISubcommandContainer
         return _subcommands.Remove(subcommand);
     }
 
+    public IEnumerable<ICommonOption> FindOptions(
+        Predicate<ICommonOption> predicate,
+        bool recursive = true)
+    {
+        IEnumerable<ICommonOption> foundOptions = Options.Where(t => predicate(t));
+
+        if (!recursive)
+            return foundOptions;
+
+        IEnumerable<ICommonOption> recursiveFoundOptions = Subcommands
+            .SelectMany(t => t.FindOptions(predicate, recursive));
+
+        return foundOptions.Concat(recursiveFoundOptions);
+    }
+
     protected virtual void AddDefaultOptions()
     {
         foreach (ParserQuantum quantum in _subcommands.Concat([this]))

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -7,5 +7,6 @@ There are the following topics:
 - [Custom converters](Documentation/CustomConverters.md)
 - [Subcommands](Documentation/Subcommands.md)
 - [Printing help](Documentation/PrintingHelp.md)
+- [Parser generation using attributes](Documentation/ParserGenerationUsingAttributes.md)
 - [Additional features](Documentation/AdditionalFeatures.md)
 - [Connect project](Documentation/ConnectProject.md)

--- a/Documentation/ParserGenerationUsingAttributes.md
+++ b/Documentation/ParserGenerationUsingAttributes.md
@@ -1,0 +1,288 @@
+# Parser Generation Using Attributes
+You can generate `ArgumentParser` using special class provided parser configuration. The configuration is specified in the form of properties and special attributes. This allows you to quickly, easily and conveniently configure the parser without the need to manually create lots of options and objects/variables that store the result of command-line arguments parsing.
+
+## Table of Contents
+*    [Attributes](#attributes)
+     *    [Configuration Attributes](#configuration-attributes)
+     *    [Option Attributes](#option-attributes)
+     *    [Group Attributes](#group-attributes)
+     *    [Subcommand Attributes](#subcommand-attributes)
+*    [Argument Parser Generation](#argument-parser-generation)
+*    [Limitations](#limitations)
+
+## Attributes
+Properties marked by special attributes will provide configuration for options and subcommands. These properties must be public and have `get` accessor. Furthermore, properties for options must have `set` accessor.
+
+### Configuration Attributes
+
+To mark class as parser generator configuration provider you should use `ParserConfigAttribute` attribute. Classes without this attrubute cannot be used as config.
+
+```cs
+[ParserConfig]
+internal class CustomParserConfig
+{
+}
+```
+
+### Option Attributes
+
+There are attributes for all types of options. Their creation is no different from the creation of the corresponding options. Only some minor changes in input parameters are possible. However, there are some limitations described in a special [section](#limitations).
+
+Below is an example of configuration with attributes for all option types.
+
+```cs
+[ParserConfig]
+internal class CustomParserConfig
+{
+    [HelpOption(
+        longName: "help",
+        shortName: "h",
+        description: "",
+        isHidden: false,
+        aliases: [])]
+    public bool ShowHelp { get; set; }
+
+    [VersionOption(
+        longName: "version",
+        shortName: "v",
+        description: "",
+        isHidden: false,
+        aliases: [])]
+    public bool ShowVersion { get; set; }
+
+    [CounterOption(
+        longName: "verbosity",
+        shortName: "V",
+        description: "",
+        isRequired: false,
+        isHidden: false,
+        isFinal: false,
+        aliases: [])
+    ]
+    public BigInteger? VerbosityLevel { get; set; }
+
+    [EnumValueOption<FileMode>(
+        longName: "mode",
+        shortName: "m",
+        description: "",
+        metaVariable: "M",
+        isRequired: true,
+        isHidden: false,
+        isFinal: false,
+        aliases: ["file-mode"],
+        choices: [FileMode.Create, FileMode.Open])
+    ]
+    public FileMode Mode { get; set; }
+
+    [FlagOption(
+        longName: "ignore-case",
+        shortName: "",
+        description: "",
+        isRequired: false,
+        isHidden: true,
+        isFinal: false,
+        aliases: [])]
+    public bool? IgnoreCase { get; set; }
+
+    [MultipleValueOption<string>(
+        longName: "files",
+        shortName: "f",
+        description: "",
+        metaVariable: "",
+        isRequired: true,
+        isHidden: false,
+        isFinal: false,
+        aliases: ["input", "input-files"],
+        contextCaptureType: ContextCaptureType.OneOrMore)
+    ]
+    public List<string> InputFiles { get; set; }
+
+    [ValueOption<Point>(
+        longName: "point",
+        shortName: "p",
+        description: "",
+        metaVariable: "",
+        isRequired: false,
+        isHidden: false,
+        isFinal: false,
+        aliases: [])
+    ]
+    public Point? Point { get; set; }
+
+    [ValueOption<double>(
+        defaultValue: 45,
+        longName: "angle",
+        shortName: "a",
+        description: "",
+        metaVariable: "A",
+        isRequired: false,
+        isHidden: false,
+        isFinal: false,
+        aliases: [],
+        choices: [0, 45, 90])
+    ]
+    public double? Angle { get; set; }
+}
+
+internal record Point(double X, double Y, double Z);
+```
+
+### Group Attributes
+Goups can be configured using `OptionGroupAttribute` attribute. In addition to specifying the group header and description, you should specify the group ID. It is necessary for the correct placement of options, since groups can have the same header. Options that you want to put in the same group must be marked with an attribute with the same ID. You should't specify header and description for all group attributes with same id. It is enough to do this for only one attribute.
+
+```cs
+[ParserConfig]
+internal class CustomParserConfig
+{
+    [FlagOption("first-name", "n")]
+    [OptionGroup("id1", "Name flags", "descripton-1")]
+    public bool ShowFirstName { get; set; }
+
+    [FlagOption("second-name", "N")]
+    [OptionGroup("id1", "", "")]
+    public bool ShowSecondName { get; set; }
+
+    [FlagOption("guide", "g")]
+    [OptionGroup("id2", "Other options", "")]
+    public bool ShowGuide { get; set; }
+
+    [CounterOption("verbosity", "v")]
+    [OptionGroup("id2", "", "")]
+    public int Verbosity { get; set; }
+}
+```
+
+Attributes for mutually exclusive groups are set in a similar manner. But unlike regular groups, mutually exclusive groups can contain options from different levels of subcommands.
+
+```cs
+[ParserConfig]
+internal class CustomParserConfig
+{
+    [FlagOption("first-name", "n")]
+    [MutuallyExclusiveOptionGroup("id", "name", "descripton")]
+    public bool ShowFirstName { get; set; }
+
+    [FlagOption("second-name", "N")]
+    [MutuallyExclusiveOptionGroup("id", "", "")]
+    public bool ShowSecondName { get; set; }
+
+    [Subcommand("status", "description")]
+    public StatusSubcommand Status { get; }
+}
+
+internal class StatusSubcommand
+{
+    [FlagOption("guide", "g")]
+    [MutuallyExclusiveOptionGroup("id", "", "")]
+    public bool ShowGuide { get; set; }
+}
+```
+
+### Subcommand Attributes
+Subcommands can be configured using `SubcommandAttribute` attribute. The corresponding property should contain instance of custom class that provide configuration for subcommand options and nested subcommands.
+
+```cs
+[ParserConfig]
+internal class CustomParserConfig
+{
+    [Subcommand("status", "description")]
+    public StatusSubcommand Status { get; }
+}
+
+internal class StatusSubcommand
+{
+    [CounterOption("verbosity", "v")]
+    public int Verbosity { get; set; }
+
+    [Subcommand("update", "description")]
+    public UpdateSubcommand Update { get; }
+}
+
+internal class UpdateSubcommand
+{
+    [FlagOption("remote", "r")]
+    public bool Remote { get; set; }
+}
+```
+
+## Argument Parser Generation
+
+At first, you need to create custom class and mark it by `ParserConfigAttribute` attribute.
+
+```cs
+[ParserConfig]
+internal class CustomParserConfig
+{
+}
+```
+
+Then you can add properties with special attributes that will provide configuration for options and subcommands.
+
+```cs
+[ParserConfig]
+internal sealed class CustomParserConfig
+{
+    [ValueOption<DateTime>("date", "d")]
+    public DateTime BirthDate { get; set; }
+}
+```
+
+Finally, you should create new instances of argument parser, argument parser generator and parser configuration classes and perform `ConfigureParser()` method.
+
+```cs
+var generator = new ArgumentParserGenerator();
+var parser = new ArgumentParser();
+var config = new CustomParserConfig();
+
+generator.ConfigureParser(parser, config);
+```
+
+After this, the parser will be configured and can be used for your own purposes.
+
+```cs
+parser.Parse(["--date", "01.01.2025"]);
+// config.BirthDate: 1/1/2025 12:00:00AM
+```
+
+## Limitations
+Using attributes in C# imposes a restriction on their argument types. An attribute argument must be a constant value or an array of such values. So the following option configurations cannot be defined directly via attributes:
+- Value restriction.
+- Custom converter.
+- Default value for some types.
+- `ValueOption` choices for some types.
+- `MultipleValueOption` choices.
+- Custom after handing action and after value parsing action.
+
+However, you can find the option using `FindOptions()` method and further configure it.
+
+```cs
+var generator = new ArgumentParserGenerator();
+var parser = new ArgumentParser();
+var config = new CustomParserConfig();
+
+generator.ConfigureParser(parser, config);
+
+ICommonOption? foundOption = parser
+    .FindOptions(t => t.LongName == "date", true)
+    .FirstOrDefault();
+
+if (foundOption is ValueOption<DateTime> birthDateOption)
+{
+    birthDateOption.ValueRestriction = new OptionValueRestriction<DateTime>(t => true);
+    birthDateOption.Converter = new ValueConverter<DateTime>(t => default);
+    birthDateOption.DefaultValue = new DefaultOptionValue<DateTime>(default);
+    birthDateOption.ValueParsed += (_, _) => Console.WriteLine("Parsed");
+
+    birthDateOption.ChangeChoices(new DateTime[] { default });
+}
+
+parser.Parse(["--date", "01.01.2025"]);
+// config.BirthDate: 1/1/0001 12:00:00AM
+
+[ParserConfig]
+internal sealed class CustomParserConfig
+{
+    [ValueOption<DateTime>("date", "d")]
+    public DateTime BirthDate { get; set; }
+}
+```

--- a/Examples/NetArgumentParser.Examples.AllUseCases/NetArgumentParser.Examples.AllUseCases.csproj
+++ b/Examples/NetArgumentParser.Examples.AllUseCases/NetArgumentParser.Examples.AllUseCases.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\Core\NetArgumentParser\NetArgumentParser.csproj" />
   </ItemGroup>
-
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
-  </PropertyGroup>
 
 </Project>

--- a/Examples/NetArgumentParser.Examples.FurtherConfigureOption/NetArgumentParser.Examples.FurtherConfigureOption.csproj
+++ b/Examples/NetArgumentParser.Examples.FurtherConfigureOption/NetArgumentParser.Examples.FurtherConfigureOption.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Core\NetArgumentParser\NetArgumentParser.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Examples/NetArgumentParser.Examples.FurtherConfigureOption/src/Program.cs
+++ b/Examples/NetArgumentParser.Examples.FurtherConfigureOption/src/Program.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Linq;
+using NetArgumentParser;
+using NetArgumentParser.Attributes;
+using NetArgumentParser.Converters;
+using NetArgumentParser.Generators;
+using NetArgumentParser.Options;
+
+var generator = new ArgumentParserGenerator();
+var parser = new ArgumentParser();
+var config = new CustomParserConfig();
+
+generator.ConfigureParser(parser, config);
+
+ICommonOption? foundOption = parser
+    .FindOptions(t => t.LongName == "date", true)
+    .FirstOrDefault();
+
+if (foundOption is ValueOption<DateTime> birthDateOption)
+{
+    birthDateOption.ValueRestriction = new OptionValueRestriction<DateTime>(t => true);
+    birthDateOption.Converter = new ValueConverter<DateTime>(t => default);
+    birthDateOption.DefaultValue = new DefaultOptionValue<DateTime>(default);
+    birthDateOption.ValueParsed += (_, _) => Console.WriteLine("Parsed");
+
+    birthDateOption.ChangeChoices(new DateTime[] { default });
+}
+
+parser.Parse(["--date", "01.01.2025"]);
+Console.WriteLine(config.BirthDate);
+
+#pragma warning disable
+[ParserConfig]
+internal sealed class CustomParserConfig
+{
+    [ValueOption<DateTime>("date", "d")]
+    public DateTime BirthDate { get; set; }
+}
+#pragma warning restore

--- a/Examples/NetArgumentParser.Examples.Simple/NetArgumentParser.Examples.Simple.csproj
+++ b/Examples/NetArgumentParser.Examples.Simple/NetArgumentParser.Examples.Simple.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\Core\NetArgumentParser\NetArgumentParser.csproj" />
   </ItemGroup>
-
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
-  </PropertyGroup>
 
 </Project>

--- a/NetArgumentParser.sln
+++ b/NetArgumentParser.sln
@@ -17,6 +17,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetArgumentParser.Examples.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetArgumentParser.Examples.AllUseCases", "Examples\NetArgumentParser.Examples.AllUseCases\NetArgumentParser.Examples.AllUseCases.csproj", "{F56E27F2-A034-4268-BF1A-9D211648D999}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetArgumentParser.Examples.FurtherConfigureOption", "Examples\NetArgumentParser.Examples.FurtherConfigureOption\NetArgumentParser.Examples.FurtherConfigureOption.csproj", "{850C9444-F85A-46FA-AE65-734A9AED1A0B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -42,11 +44,16 @@ Global
 		{F56E27F2-A034-4268-BF1A-9D211648D999}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F56E27F2-A034-4268-BF1A-9D211648D999}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F56E27F2-A034-4268-BF1A-9D211648D999}.Release|Any CPU.Build.0 = Release|Any CPU
+		{850C9444-F85A-46FA-AE65-734A9AED1A0B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{850C9444-F85A-46FA-AE65-734A9AED1A0B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{850C9444-F85A-46FA-AE65-734A9AED1A0B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{850C9444-F85A-46FA-AE65-734A9AED1A0B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{2C140CC4-00C6-4017-8CB3-68B32CC7C058} = {649A384F-36AE-432F-8AF5-D28674D77B7D}
 		{3AB4D374-88E7-4681-B9C7-2C3D57DF8DC8} = {DCD4DEB9-0ACD-4CA0-AAF6-A7298C908266}
 		{540F9CC0-410A-48D4-B44E-8B3845C66F0B} = {5F8AF5AE-CF52-4ECE-92B8-EE6F7F401E98}
 		{F56E27F2-A034-4268-BF1A-9D211648D999} = {5F8AF5AE-CF52-4ECE-92B8-EE6F7F401E98}
+		{850C9444-F85A-46FA-AE65-734A9AED1A0B} = {5F8AF5AE-CF52-4ECE-92B8-EE6F7F401E98}
 	EndGlobalSection
 EndGlobal

--- a/Tests/NetArgumentParser.Tests/src/Models/Configurations/MutuallyExclusiveOptionGroupWithoutDuplicateInfoParserGeneratorConfig.cs
+++ b/Tests/NetArgumentParser.Tests/src/Models/Configurations/MutuallyExclusiveOptionGroupWithoutDuplicateInfoParserGeneratorConfig.cs
@@ -1,0 +1,23 @@
+using NetArgumentParser.Attributes;
+
+namespace NetArgumentParser.Tests.Models.Configurations;
+
+[ParserConfig]
+internal class MutuallyExclusiveOptionGroupWithoutDuplicateInfoParserGeneratorConfig
+{
+    public const string GroupId = "group1";
+    public const string GroupHeader = "group1 header";
+    public const string GroupDescription = "group1 description";
+
+    [FlagOption("flag1")]
+    [MutuallyExclusiveOptionGroup(GroupId, "", "")]
+    public bool Flag1 { get; set; }
+
+    [FlagOption("flag2")]
+    [MutuallyExclusiveOptionGroup(GroupId, GroupHeader, GroupDescription)]
+    public bool Flag2 { get; set; }
+
+    [FlagOption("flag3")]
+    [MutuallyExclusiveOptionGroup(GroupId, "", "")]
+    public bool Flag3 { get; set; }
+}

--- a/Tests/NetArgumentParser.Tests/src/Models/Configurations/OptionGroupWithoutDuplicateInfoParserGeneratorConfig.cs
+++ b/Tests/NetArgumentParser.Tests/src/Models/Configurations/OptionGroupWithoutDuplicateInfoParserGeneratorConfig.cs
@@ -1,0 +1,23 @@
+using NetArgumentParser.Attributes;
+
+namespace NetArgumentParser.Tests.Models.Configurations;
+
+[ParserConfig]
+internal class OptionGroupWithoutDuplicateInfoParserGeneratorConfig
+{
+    public const string GroupId = "group1";
+    public const string GroupHeader = "group1 header";
+    public const string GroupDescription = "group1 description";
+
+    [FlagOption("flag1")]
+    [OptionGroup(GroupId, "", "")]
+    public bool Flag1 { get; set; }
+
+    [FlagOption("flag2")]
+    [OptionGroup(GroupId, GroupHeader, GroupDescription)]
+    public bool Flag2 { get; set; }
+
+    [FlagOption("flag3")]
+    [OptionGroup(GroupId, "", "")]
+    public bool Flag3 { get; set; }
+}

--- a/Tests/NetArgumentParser.Tests/src/ParserGeneratorTests.cs
+++ b/Tests/NetArgumentParser.Tests/src/ParserGeneratorTests.cs
@@ -175,6 +175,54 @@ public class ParserGeneratorTests
     }
 
     [Fact]
+    public void ConfigureParser_OptionGroupWithoutDuplicateInfo_CreatedGroupWithCorrectParameters()
+    {
+        var generator = new ArgumentParserGenerator();
+        var argumentParser = new ArgumentParser();
+        var config = new OptionGroupWithoutDuplicateInfoParserGeneratorConfig();
+
+        generator.ConfigureParser(argumentParser, config);
+
+        Assert.Equal(2, argumentParser.OptionGroups.Count);
+
+        OptionGroup<ICommonOption>? group = argumentParser.OptionGroups
+            .FirstOrDefault(t => t != argumentParser.DefaultGroup);
+
+        Assert.NotNull(group);
+
+        Assert.Equal(
+            OptionGroupWithoutDuplicateInfoParserGeneratorConfig.GroupHeader,
+            group.Header);
+
+        Assert.Equal(
+            OptionGroupWithoutDuplicateInfoParserGeneratorConfig.GroupDescription,
+            group.Description);
+    }
+
+    [Fact]
+    public void ConfigureParser_MutuallyExclusiveOptionGroup_CreatedGroupWithCorrectParameters()
+    {
+        var generator = new ArgumentParserGenerator();
+        var argumentParser = new ArgumentParser();
+        var config = new MutuallyExclusiveOptionGroupWithoutDuplicateInfoParserGeneratorConfig();
+
+        generator.ConfigureParser(argumentParser, config);
+
+        Assert.Equal(1, argumentParser.MutuallyExclusiveOptionGroups.Count);
+
+        MutuallyExclusiveOptionGroup<ICommonOption> group =
+            argumentParser.MutuallyExclusiveOptionGroups[0];
+
+        Assert.Equal(
+            MutuallyExclusiveOptionGroupWithoutDuplicateInfoParserGeneratorConfig.GroupHeader,
+            group.Header);
+
+        Assert.Equal(
+            MutuallyExclusiveOptionGroupWithoutDuplicateInfoParserGeneratorConfig.GroupDescription,
+            group.Description);
+    }
+
+    [Fact]
     public void ConfigureParser_NotValidConfig_ThrowsExceptionIfSpecifiedDuplicateOptionName()
     {
         var generator = new ArgumentParserGenerator();


### PR DESCRIPTION
Expand functionality:
- Add the ability to not specify the same header and description for same groups.
- Add the ability to find options by predicate.
- Add the ability to set default value, choices and value restriction to created value option.